### PR TITLE
adding MODULE_FILENAME definition to name-defines.inc

### DIFF
--- a/include/name-defines.inc
+++ b/include/name-defines.inc
@@ -28,6 +28,7 @@
 # Module macros
 %define MODULE_PREFIX   /tmpmod 
 %define MODULE_DIR      %{MODULE_PREFIX}/%{MODULE_SUFFIX}
+%define MODULE_FILENAME %{version}.lua
 
 # Install macros
 %define INSTALL_PREFIX  /tmprpm


### PR DESCRIPTION
This is in response to some of the comments in issue #4.

This change is also consistent with the name-defines.inc file located here:
https://github.com/TACC/hpc_spec/tree/st3
